### PR TITLE
Move detection code earlier and report.

### DIFF
--- a/pkg/internal/discover/attacher.go
+++ b/pkg/internal/discover/attacher.go
@@ -93,7 +93,10 @@ func (ta *TraceAttacher) getTracer(ie *Instrumentable) (*ebpf.ProcessTracer, boo
 	case svc.InstrumentableGolang:
 		// gets all the possible supported tracers for a go program, and filters out
 		// those whose symbols are not present in the ELF functions list
-		if ta.Cfg.Discovery.SkipGoSpecificTracers {
+		if ta.Cfg.Discovery.SkipGoSpecificTracers || ie.InstrumentationError != nil {
+			if ie.InstrumentationError != nil {
+				ta.log.Warn("Unsupported Go program detected, using generic instrumentation", "error", ie.InstrumentationError)
+			}
 			if ta.reusableTracer != nil {
 				programs = newNonGoTracersGroupUProbes(ta.Cfg, ta.Metrics)
 			} else {

--- a/pkg/internal/goexec/gofile.go
+++ b/pkg/internal/goexec/gofile.go
@@ -41,10 +41,6 @@ func findLibraryVersions(elfFile *elf.File) (map[string]string, error) {
 	goVersion = strings.ReplaceAll(goVersion, "go", "")
 	log().Debug("Go version detected", "version", goVersion)
 
-	if !supportedGoVersion(goVersion) {
-		return nil, fmt.Errorf("unsupported Go version: %v. Minimum version is %v", goVersion, minGoVersion)
-	}
-
 	modsMap := parseModules(modules)
 	modsMap["go"] = goVersion
 	return modsMap, nil

--- a/pkg/internal/goexec/instructions.go
+++ b/pkg/internal/goexec/instructions.go
@@ -24,6 +24,11 @@ func instrumentationPoints(elfF *elf.File, funcNames []string) (map[string]FuncO
 		return nil, err
 	}
 
+	goVersion, _, err := getGoDetails(elfF)
+	if err == nil && !supportedGoVersion(goVersion) {
+		return nil, fmt.Errorf("unsupported Go version: %v. Minimum supported version is %v", goVersion, minGoVersion)
+	}
+
 	gosyms := elfF.Section(".gosymtab")
 
 	var allSyms map[string]exec.Sym

--- a/pkg/internal/goexec/structmembers.go
+++ b/pkg/internal/goexec/structmembers.go
@@ -115,11 +115,6 @@ func structMemberOffsets(elfFile *elf.File) (FieldOffsets, error) {
 	var expected map[string]struct{}
 	dwarfData, err := elfFile.DWARF()
 	if err == nil {
-		_, _, err := getGoDetails(elfFile)
-		if err != nil {
-			return nil, fmt.Errorf("getting Go details: %w", err)
-		}
-
 		offs, expected = structMemberOffsetsFromDwarf(dwarfData)
 		if len(expected) > 0 {
 			log().Debug("Fields not found in the DWARF file", "fields", expected)


### PR DESCRIPTION
Hey @myhro, as you noticed I was wrong before and we had to move that check earlier. It also needed a bit more work to make us pick the kernel based instrumentation, since we still detect the executable as Go and we would ignore it. I added a field in the discovery structure to remember that there were errors while attempting to instrument a Go executable and then warn the users that we would use generic instrumentation.

You can simply merge this PR on your branch if you agree, or propose another solution, both work :).